### PR TITLE
Convert pyproject.toml to older poetry format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,20 @@
-[project]
+[tool.poetry]
 name = "gtmorphtest"
 version = "0.1.0"
 description = "Morphological FST testing for HFST automata and YAML test descriptions"
 authors = [
-    {name = "Brendan Molloy"},
-    {name = "Sjur N Moshagen",email = "sjurnm@mac.com"},
-    {name = "Jonathan Washington"},
-    {name = "Daniel Swanson"},
-    {name = "Flammie A Pirinen",email = "flammie@iki.fi"}
+    "Brendan Molloy",
+    "Sjur N Moshagen <sjurnm@mac.com>",
+    "Jonathan Washington",
+    "Daniel Swanson",
+    "Flammie A Pirinen <flammie@iki.fi>"
 ]
-license = {text = "CC0"}
+license = "CC0"
 readme = "README.md"
-requires-python = ">=3.9"
-dependencies = [
-    "pyyaml (>=6.0.2,<7.0.0)"
-]
 
+[tool.poetry.dependencies]
+python = "^3.9"
+pyyaml = ">=6.0.2,<7.0.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
https://github.com/divvun/morph-test/commit/e9c903cb73b11275e1aeac409d141d0137d4d1f8 is unfortunately not sufficient. Older Poetry does not understand the PEP 621 `[project]` format. Akin to https://github.com/divvun/GiellaLTLexTools/pull/1/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711, this is what's needed to build on Ubuntu 22.04.